### PR TITLE
Ambi-Light: Add complex smoothing of colors

### DIFF
--- a/Ambi-Light-LE46B650/.gitignore
+++ b/Ambi-Light-LE46B650/.gitignore
@@ -2,3 +2,5 @@
 .piolibdeps
 CMakeListsPrivate.txt
 /.idea/
+.clang_complete
+.gcc-flags.json

--- a/Ambi-Light-LE46B650/README.md
+++ b/Ambi-Light-LE46B650/README.md
@@ -22,3 +22,6 @@ Note:
 | RX        | RXD      | DATA      | RXD                           |
 | G         | GND      | GND       | Ground                        |
 | 5V / 3V3  | - / 3.3V | +V        | Power                         |
+
+*   Connect a capacitor with a capacitance between 100uF and 1000uF from power to ground to smooth out the power supply.
+*   Add a 220 or 470 Ohm resistor between the Arduino digital output pin and the strip data input pin to reduce noise on that line.

--- a/Ambi-Light-LE46B650/src/ambi.cpp
+++ b/Ambi-Light-LE46B650/src/ambi.cpp
@@ -44,10 +44,17 @@ void loop() {
 #ifndef SMOOTH_FADING
             strip->SetPixelColor(p, RgbColor(buffer[0 + 3 * p], buffer[1 + 3 * p], buffer[2 + 3 * p]));
 #else
-            RgbColor current_color = strip->GetPixelColor(p);
-            strip->SetPixelColor(p, RgbColor((uint8_t) (0.5 * (buffer[0 + 3 * p] + current_color.R)),
-                                             (uint8_t) (0.5 * (buffer[1 + 3 * p] + current_color.G)),
-                                             (uint8_t) (0.5 * (buffer[2 + 3 * p] + current_color.B))));
+            RgbColor color = RgbColor((uint8_t) (0.5 * (buffer[0 + 3 * p] + strip->GetPixelColor(p).R)),
+                                      (uint8_t) (0.5 * (buffer[1 + 3 * p] + strip->GetPixelColor(p).G)),
+                                      (uint8_t) (0.5 * (buffer[2 + 3 * p] +
+                                                        strip->GetPixelColor(p).B))),
+                    color_next = p < 2 * (HORIZONTAL_LEDS + VERTICAL_LEDS) - 1 ?
+                                 strip->GetPixelColor((uint16_t) (p + 1)) : strip->GetPixelColor(0),
+                    color_prev = p > 0 ? strip->GetPixelColor((uint16_t) (p - 1)) :
+                                 strip->GetPixelColor(2 * (HORIZONTAL_LEDS + VERTICAL_LEDS) - 1);
+            strip->SetPixelColor(p, RgbColor((uint8_t) (0.3 * color_prev.R + 0.4 * color.R + 0.3 * color_next.R),
+                                             (uint8_t) (0.3 * color_prev.G + 0.4 * color.G + 0.3 * color_next.G),
+                                             (uint8_t) (0.3 * color_prev.B + 0.4 * color.B + 0.3 * color_next.B)));
 #endif
         }
         strip->Show();


### PR DESCRIPTION
- Smoothing is averaged between previous color and colors
  of nearest leds with ratio 0.3/0.4/0.3 R/P/L
- Update Ambi README with more hardware info

Signed-off-by: Martin Mihálek <aenniw@gmail.com>