### PR TITLE
Add wc matching and streams into rest-service

### DIFF
--- a/lib/commons/commons.h
+++ b/lib/commons/commons.h
@@ -6,6 +6,9 @@
 
 #define CONFIG_GLOBAL_JSON      "/json/config-global.json"
 
+#define MIN(a,b) ((a<b)?a:b)
+#define MAX(a,b) ((a>b)?a:b)
+
 void *checked_free(void *ptr);
 
 class Service {

--- a/lib/file_system/file_streams.cpp
+++ b/lib/file_system/file_streams.cpp
@@ -1,0 +1,52 @@
+#include "file_streams.h"
+
+MultiFileStream::MultiFileStream(std::initializer_list<const char *> fs) {
+    files = new char *[fs.size()];
+    for (auto f :fs) {
+        files[files_len++] = (char *) f;
+    }
+}
+
+uint32_t MultiFileStream::size() const {
+    uint32_t len = 0;
+    for (uint32_t i = 0; i < files_len; i++) {
+        yield(); // WATCHDOG/WIFI feed
+        File file = SPIFFS.open(files[i], "r");
+        if (file) {
+            len += file.size();
+            file.close();
+        }
+    }
+    return len;
+}
+
+int MultiFileStream::read(byte *buf, uint16_t nbyte) {
+    int rd = 0, cp = 0;
+    for (uint32_t i = 0; i < files_len && rd < nbyte; i++) {
+        yield(); // WATCHDOG/WIFI feed
+        File f = SPIFFS.open(files[i], "r");
+        if (!f) {
+            continue;
+        }
+        if (p > cp + f.size()) {
+            cp += f.size();
+        } else {
+            f.seek(p - cp, SeekSet);
+            rd += f.read(buf + rd, (size_t)(nbyte - rd));
+        }
+        f.close();
+    }
+    p += rd;
+    return rd;
+}
+
+int MultiFileStream::available() const {
+    const uint32_t s = size();
+    return (int) ((s - p) > 0 ? s - p : 0);
+};
+
+const char *MultiFileStream::name() const { return ""; }
+
+void MultiFileStream::rewind() { p = 0; }
+
+MultiFileStream::~MultiFileStream() { delete files; }

--- a/lib/file_system/file_streams.h
+++ b/lib/file_system/file_streams.h
@@ -1,0 +1,43 @@
+#ifndef ESP8266_PROJECTS_ROOT_FILE_STREAMS_H
+#define ESP8266_PROJECTS_ROOT_FILE_STREAMS_H
+
+#include <FS.h>
+#include <initializer_list>
+
+class FStream {
+public:
+    virtual int read(byte *buf, uint16_t nbyte) = 0;
+
+    virtual int available() const = 0;
+
+    virtual uint32_t size() const = 0;
+
+    virtual const char *name() const = 0;
+
+    virtual void rewind()=0;
+
+    virtual ~FStream() {};
+};
+
+class MultiFileStream : public FStream {
+private:
+    char **files;
+    uint32_t p = 0, files_len = 0;
+public:
+    MultiFileStream(std::initializer_list<const char *> fs);
+
+    virtual int read(byte *buf, uint16_t nbyte) override;
+
+    int available() const override;
+
+    uint32_t size() const override;
+
+    const char *name() const override;
+
+    void rewind() override;
+
+    ~MultiFileStream();
+
+};
+
+#endif //ESP8266_PROJECTS_ROOT_FILE_STREAMS_H

--- a/lib/file_system/file_system.cpp
+++ b/lib/file_system/file_system.cpp
@@ -103,3 +103,22 @@ void ConfigJSON::del_default(JsonObject &json, std::initializer_list<const char 
         }
     }
 }
+
+bool ICACHE_FLASH_ATTR copy_file(const char *src_name, const char *dst_name, const bool overwrite) {
+    if (!overwrite && SPIFFS.exists(dst_name)) return false;
+    File dst = SPIFFS.open(dst_name, "w");
+    if (!dst) return false;
+    File src = SPIFFS.open(src_name, "r");
+    if (!src) {
+        dst.close();
+        return false;
+    }
+    while (src.available()) {
+        dst.write((uint8_t) src.read());
+    }
+    src.close();
+    dst.flush();
+    dst.close();
+    Log::println("File %s copied to %s", src_name, dst_name);
+    return true;
+}

--- a/lib/file_system/file_system.h
+++ b/lib/file_system/file_system.h
@@ -104,4 +104,6 @@ public:
     static char *ICACHE_FLASH_ATTR getString(const char *file, std::initializer_list<const char *> keys);
 };
 
+bool ICACHE_FLASH_ATTR copy_file(const char *src_name, const char *dst_name, const bool overwrite = false);
+
 #endif /* WEMOS_D1_FILESYSTEM_H_ */


### PR DESCRIPTION
- uri matching supports wildcards [+,?] where + matchs any character until
  new slash and ? match zero ore one slash
- add option to provide streams to uri handlers
- add copy method to file_system lib
- add simple multi-file stream that joins multiple files

Signed-off-by: Martin Mihálek <aenniw@gmail.com>